### PR TITLE
Export Note for convenience ?

### DIFF
--- a/src/note.jl
+++ b/src/note.jl
@@ -55,3 +55,4 @@ import Base.+, Base.-, Base.==
     n1.velocity == n2.velocity
 
 export Bs, C, Cs, Db, D, Ds, Eb, E, Fb, Es, F, Fs, Gb, G, Gs, Ab, A, As, Bb, B, Cb
+export Note


### PR DESCRIPTION
Since this package is much more likely to be used only with `using` , and since the type `Note` is one of the core parts of the package, I think it is convenient to also `export Note` allowing someone to directly do `Note(stuff)` instead of `MIDI.Note(stuff)`