### PR TITLE
Many more docstrings and some exports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 julia:
 #  - release TODO: Re-enable this when travis-ci has julia 0.4 as the release version.
-  - nightly
+  - 0.5
   - 0.4
 notifications:
   email: false

--- a/src/MIDI.jl
+++ b/src/MIDI.jl
@@ -1,3 +1,6 @@
+"""
+A Julia library for reading and writing Midi files.
+"""
 module MIDI
 
 include("trackevent.jl")

--- a/src/metaevent.jl
+++ b/src/metaevent.jl
@@ -1,3 +1,9 @@
+export MetaEvent
+
+"""
+    MetaEvent <: TrackEvent
+See `TrackEvent`.
+"""
 type MetaEvent <: TrackEvent
     dT::Int
     metatype::UInt8

--- a/src/midievent.jl
+++ b/src/midievent.jl
@@ -1,3 +1,9 @@
+export MIDIEvent
+
+"""
+    MIDIEvent <: TrackEvent
+See `TrackEvent`.
+"""
 type MIDIEvent <: TrackEvent
     dT::Int
     status::UInt8

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -52,7 +52,7 @@ end
 Write a `MIDIFile` as a midi datatype to the given filename.
 """
 function writeMIDIfile(filename::AbstractString, data::MIDIFile)
-    if filename[end-4] != ".mid"
+    if filename[end-4:end] != ".mid"
       filename *= ".mid"
     end
 

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -1,3 +1,5 @@
+export MIDIFile, readMIDIfile, writeMIDIfile
+
 """
     MIDIFile <: Any
 Type representing a file of MIDI data.
@@ -66,5 +68,3 @@ function writeMIDIfile(filename::AbstractString, data::MIDIFile)
 
     close(f)
 end
-
-export MIDIFile, readMIDIfile, writeMIDIfile

--- a/src/miditrack.jl
+++ b/src/miditrack.jl
@@ -1,12 +1,17 @@
 export getnotes, addnote, addnotes
 
-#=
+"""
+    MIDITrack <: Any
+
+`MIDITrack` is simply a container for `TrackEvents`, since its only field is
+`events::Vector{TrackEvent}`.
+
 Track chunks begin with four bytes spelling out "MTrk", followed by the length
-in bytes of the track (see readvariablelength in util.jl), followed by a sequence
+(in bytes) of the track (see `readvariablelength`), followed by a sequence
 of events.
-=#
+"""
 type MIDITrack
-    events::Array{TrackEvent, 1}
+    events::Vector{TrackEvent}
 
     MIDITrack() = new(TrackEvent[])
     MIDITrack(events) = new(events)
@@ -150,8 +155,11 @@ end
 """
     getnotes(track::MIDITrack)
 Find all NOTEON and NOTEOFF midi events in the `track` that correspond to
-the same note (pitch) and convert them into
+the same note value (pitch) and convert them into
 the `Note` datatype provided by this Package. Ordering is done based on position.
+
+There are special cases where NOTEOFF is actually encoded as NOTEON with 0 velocity.
+`getnotes` takes care of this.
 
 Returns: `Vector{Note}`.
 """
@@ -160,7 +168,7 @@ function getnotes(track::MIDITrack)
     tracktime = UInt64(0)
     for (i, event) in enumerate(track.events)
         tracktime += event.dT
-        # Read through events until a noteon with velocity higher tha 0 is found 
+        # Read through events until a noteon with velocity higher tha 0 is found
         if isa(event, MIDIEvent) && event.status & 0xF0 == NOTEON && event.data[2] > 0
             duration = UInt64(0)
             for event2 in track.events[i+1:length(track.events)]
@@ -177,8 +185,14 @@ function getnotes(track::MIDITrack)
     sort!(notes, lt=((x, y)->x.position<y.position))
 end
 
-# Change the program (instrument) on the given channel. Time is absolute, not relative to the last event.
+"""
+    programchange(track::MIDITrack, time::Integer, channel::UInt8, program::UInt8)
+
+Change the program (instrument) on the given channel.
+Time is absolute, not relative to the last event.
+
+The `program` must be specified in the range 0-127, **not** in 1-128!
+"""
 function programchange(track::MIDITrack, time::Integer, channel::UInt8, program::UInt8)
-    program = program - 1 # Program changes are typically given in range 1-128, but represented internally as 0-127.
     addevent(track, time, MIDIEvent(0, PROGRAMCHANGE | channel, UInt8[program]))
 end

--- a/src/miditrack.jl
+++ b/src/miditrack.jl
@@ -191,8 +191,9 @@ end
 Change the program (instrument) on the given channel.
 Time is absolute, not relative to the last event.
 
-The `program` must be specified in the range 0-127, **not** in 1-128!
+The `program` must be specified in the range 1-128, **not** in 0-127!
 """
 function programchange(track::MIDITrack, time::Integer, channel::UInt8, program::UInt8)
+    program -= 1
     addevent(track, time, MIDIEvent(0, PROGRAMCHANGE | channel, UInt8[program]))
 end

--- a/src/note.jl
+++ b/src/note.jl
@@ -4,7 +4,7 @@ export Note
     Note <: Any
 Data structure describing a "music note".
 ## Fields:
-* `value::UInt8` : Pitch, starting from C0, adding one per semitone.
+* `value::UInt8` : Pitch, starting from C0, adding one per semitone (middle-C is 60).
 * `duration::UInt64` : Duration in ticks.
 * `position::UInt64` : Position in absolute time (since beggining of track), in ticks.
 * `channel::UInt8` : Channel of the track that the note is played on.

--- a/src/sysexevent.jl
+++ b/src/sysexevent.jl
@@ -1,3 +1,8 @@
+export SysexEvent
+"""
+    SysexEvent <: TrackEvent
+See `TrackEvent`.
+"""
 type SysexEvent <: TrackEvent
     dT::Int64
     data::Array{UInt8,1}

--- a/src/trackevent.jl
+++ b/src/trackevent.jl
@@ -1,12 +1,21 @@
-# Abstract type for MIDI events
-abstract TrackEvent
+export TrackEvent
 
-#=
-All track events begin with a variable length time value (see readvariablelength()) and must have a field named dT.
-MIDI events start with a MIDI channel message defined in constants.jl. They're followed by 1 or 2 bytes, depending on the
-channel message (see EVENTTYPETOLENGTH). If no valid channel message is identified, the previous seen channel message is used.
-Meta events and sysex events both begin with a specific byte (see constants.jl)
-=#
+"""
+    TrackEvent <: Any
+Abstract supertype for all MIDI events.
+
+All track events begin with a variable length time value (see `readvariablelength`)
+and must have a field named dT which contains it. This number notes how many ticks
+after the last event, the current even takes place.
+
+`MIDIEvent`s then resume with a MIDI channel message
+defined in `constants.jl`. They're followed by 1 or 2 bytes, depending on the
+channel message (see `EVENTTYPETOLENGTH`). If no valid channel message is identified,
+the previous seen channel message is used. After that the MIDI command is encoded.
+
+`MetaEvent`s and `SysexEvent`s both resume with a specific byte (see `constants.jl`).
+"""
+abstract TrackEvent
 
 function dt(e::TrackEvent)
     e.dT

--- a/src/variablelength.jl
+++ b/src/variablelength.jl
@@ -1,9 +1,12 @@
+export readvariablelength, writevariablelength
+"""
+    readvariablelength(f::IO)
+Variable length numbers in MIDI files are represented as a sequence of bytes.
+If the first bit is 0, we're looking at the last byte in the sequence. The remaining
+7 bits indicate the number.
+"""
 function readvariablelength(f::IO)
-    #=
-    Variable length numbers in MIDI files are represented as a sequence of bytes.
-    If the first bit is 0, we're looking at the last byte in the sequence. The remaining
-    7 bits indicate the number.
-    =#
+
     mask = 0b10000000
     notmask = ~mask
     # Read the first byte
@@ -24,7 +27,13 @@ function readvariablelength(f::IO)
     end
 end
 
-function writevariablelength(f::IO, number::Int64)
+
+"""
+    writevariablelength(f::IO, number::Int)
+Write on `f` the given `number`, firstly converting it to the "variable length" format.
+See the documentation for more.
+"""
+function writevariablelength(f::IO, number::Int)
     if number < 128
         write(f, UInt8(number))
     else


### PR DESCRIPTION
Added doc at all functions that it was reasonable to have documentation
(i.e. they might be called by a user).

Changed a bit `programchange` since now the docstring tells the user
what input it expects.