### PR TITLE
Update midifile.jl

### DIFF
--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -52,7 +52,7 @@ end
 Write a `MIDIFile` as a ".mid" file to the given filename.
 """
 function writeMIDIfile(filename::AbstractString, data::MIDIFile)
-    if filename[end-3:end] != ".mid"
+    if length(filename) < 4 || filename[end-3:end] != ".mid"
       filename *= ".mid"
     end
 


### PR DESCRIPTION
Fixed writeMIDIfile so that it no longer errors when the file name is shorter than 4 characters.