### PR TITLE
Make `MIDIFile()` an outer constructor

### DIFF
--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -15,7 +15,7 @@ type MIDIFile
     tracks::Array{MIDITrack, 1} # An array of tracks
 end
 
-MIDIFile() = new(0,96,MIDITrack[])
+MIDIFile() = MIDIFile(0,96,MIDITrack[])
 
 function readMIDIfileastype0(filename::AbstractString)
 	MIDIfile = readMIDIfile(filename)

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -13,9 +13,9 @@ type MIDIFile
     format::UInt16 # The format of the file. Can be 0, 1 or 2
     timedivision::Int16 # The time division of the track. Ticks per beat.
     tracks::Array{MIDITrack, 1} # An array of tracks
-
-    MIDIFile() = new(0,96,MIDITrack[])
 end
+
+MIDIFile() = new(0,96,MIDITrack[])
 
 function readMIDIfileastype0(filename::AbstractString)
 	MIDIfile = readMIDIfile(filename)


### PR DESCRIPTION
This enables the default inner constructor that allows you to set the values of the parameters without needing a workaround like the following:

```julia
function MIDI.MIDIFile(format, timedivision, tracks)
    file = MIDIFile()
    file.format = format
    file.timedivision = timedivision
    file.tracks = tracks
    file
end
```