### PR TITLE
readMIDIfile now checks file extension case-insensitively.

### DIFF
--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -63,7 +63,7 @@ end
 Write a `MIDIFile` as a ".mid" file to the given filename.
 """
 function writeMIDIfile(filename::AbstractString, data::MIDIFile)
-    if length(filename) < 4 || filename[end-3:end] != ".mid"
+    if length(filename) < 4 || lowercase(filename[end-3:end]) != ".mid"
       filename *= ".mid"
     end
 


### PR DESCRIPTION
This is untested but should theoretically fix #80 since I was able to fix the issue by renaming my file with a lowercase `.mid` extension.