### PR TITLE
disallow writing invalid VLVs

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -94,7 +94,7 @@ function fromabsolutetime!(track::MIDITrack)
 		t1 = event.dT
 		event.dT = event.dT - t0
 		if event.dT < 0
-			error("Negative relative dT")
+			error("Negative deltas are not allowed. Please reorder your events.")
 		end
 		t0 = t1
 	end

--- a/src/metaevent.jl
+++ b/src/metaevent.jl
@@ -25,6 +25,9 @@ function readmetaevent(dT::Int, f::IO)
 end
 
 function writeevent(f::IO, event::MetaEvent)
+    if event.dT < 0
+        error("Negative deltas are not allowed. Please reorder your events.")
+    end
     writevariablelength(f, event.dT)
     write(f, META)
     write(f, event.metatype)

--- a/src/midievent.jl
+++ b/src/midievent.jl
@@ -46,6 +46,10 @@ function readMIDIevent(dT::Int, f::IO, laststatus::UInt8)
 end
 
 function writeevent(f::IO, event::MIDIEvent, writestatus::Bool)
+    if event.dT < 0
+        error("Negative deltas are not allowed. Please reorder your events.")
+    end
+    
     writevariablelength(f, event.dT)
 
     if writestatus

--- a/src/sysexevent.jl
+++ b/src/sysexevent.jl
@@ -34,6 +34,10 @@ function readsysexevent(dT::Int, f::IO)
 end
 
 function writeevent(f::IO, event::SysexEvent)
+    if event.dT < 0
+        error("Negative deltas are not allowed. Please reorder your events.")
+    end
+    
     writevariablelength(f, event.dT)
     write(f, SYSEX)
     writevariablelength(f, length(event.data) + 1) # +1 for the ending F7

--- a/src/variablelength.jl
+++ b/src/variablelength.jl
@@ -34,6 +34,11 @@ Write on `f` the given `number`, firstly converting it to the "variable length" 
 See the documentation for more.
 """
 function writevariablelength(f::IO, number::Int)
+    if number < 0 || number > 0x0FFFFFFF
+        error("Unable to write variable length value ",
+              string(number),
+              " as it does not fit in the range [0, 0x0FFFFFFF].")
+    end
     if number < 128
         write(f, UInt8(number))
     else

--- a/test/negative_delta.jl
+++ b/test/negative_delta.jl
@@ -1,6 +1,16 @@
 cd(@__DIR__)
 
-@testset "negative delta" begin
+@testset "reading negative delta" begin
     midi = readMIDIfile("negative_delta.mid")
     @test midi.tracks[1].events[3].dT == -48
+end
+
+@testset "writing negative delta" begin
+    stream = IOBuffer()
+    @test_throws ErrorException MIDI.writeevent(stream, MIDIEvent(-1, 0x80, [0x00, 0x00]))
+    @test_throws ErrorException MIDI.writeevent(stream, MetaEvent(-1, 0x51, [0x00, 0x00, 0x01]))
+    @test_throws ErrorException MIDI.writeevent(stream, SysexEvent(-1, [0x01]))
+    @test_throws ErrorException MIDI.writevariablelength(stream, -1)
+    @test_throws ErrorException MIDI.writevariablelength(stream, Int(0x1FFFFFFF))
+    close(stream)
 end


### PR DESCRIPTION
This PR adds checks that disallow writing invalid variable length values.
In particular, when attempting to write negative `dT`s, an error is thrown.

Negative `dT`s are only checked in `writeevent`, not in the event constructors, as this would also disallow _reading_ negative `dT`s.