### PR TITLE
Introduce AbstractNote

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ end
 Value is a number indicating pitch class & octave (middle-C is 60). Position is an absolute time (in ticks) within the track. Please note that velocity cannot be higher than 127 (0x7F). Integers can be added to, or subtracted from notes to change the pitch, and notes can be directly compared with ==. Constants exist for the different pitch values at octave 0. MIDI.C, MIDI.Cs, MIDI.Db, etc. Enharmonic note constants exist as well (MIDI.Fb). Just add 12*n to the note to transpose to octave n.
 
 ```julia
-mutable struct Notes
-    notes::Vector{Note}
+mutable struct Note{N<:AbstractNote}
+    notes::Vector{N}
     tpq::Int16
 end
 ```

--- a/src/miditrack.jl
+++ b/src/miditrack.jl
@@ -130,11 +130,13 @@ function addevent!(track::MIDITrack, time::Integer, newevent::TrackEvent)
 end
 
 """
-    addnote!(track::MIDITrack, note::Note)
+    addnote!(track::MIDITrack, note::AbstractNote)
 Add given `note` to given `track`, internally doing the translation from
 absolute time to relative time.
 """
-function addnote!(track::MIDITrack, note::Note)
+function addnote!(track::MIDITrack, anote::AbstractNote)
+    # Convert to `Note`
+    note = Note(anote)
     for (status, position) in [(NOTEON, note.position), (NOTEOFF, note.position + note.duration)]
         addevent!(track, position, MIDIEvent(0, status | note.channel, UInt8[note.value, note.velocity]))
     end
@@ -164,7 +166,7 @@ Notice that the first track of a `midi` doesn't have any notes.
     getnotes(track::MIDITrack, tpq = 960)
 Find the notes from `track` directly, passing also the ticks per quarter note.
 
-Returns: `Notes`, setting the ticks per quarter note as `tpq`. You can find
+Returns: `Notes{Note}`, setting the ticks per quarter note as `tpq`. You can find
 the originally exported
 ticks per quarter note from the original `MIDIFile` through `midi.tpq`.
 """

--- a/src/note.jl
+++ b/src/note.jl
@@ -1,7 +1,8 @@
-export Note, Notes
+export Note, Notes, AbstractNote
+abstract type AbstractNote end
 
 """
-    Note <: Any
+    Note <: AbstractNote
 Data structure describing a "music note".
 ## Fields:
 * `value::UInt8` : Pitch, starting from C0 = 0, adding one per semitone (middle-C is 60).
@@ -10,7 +11,7 @@ Data structure describing a "music note".
 * `channel::UInt8` : Channel of the track that the note is played on.
 * `velocity::UInt8` : Dynamic intensity. Cannot be higher than 127 (0x7F).
 """
-mutable struct Note
+mutable struct Note <: AbstractNote
     value::UInt8
     duration::UInt
     position::UInt
@@ -43,31 +44,31 @@ import Base.+, Base.-, Base.==
     n1.velocity == n2.velocity
 
 """
-    Notes <: Any
+    Notes{N<:AbstractNote}
 Data structure describing a collection of "music notes", bundled with a ticks
 per quarter note measure.
 ## Fields:
-* `notes::Vector{Note}`
+* `notes::Vector{N}`
 * `tpq::Int16` : Ticks per quarter note. Defines the fundamental unit of measurement
    of a note's position and duration, as well as the length of one quarter note.
    Takes values from 1 to 960.
 
 `Notes` is iterated and accessed as if iterating or accessing its field `notes`.
 """
-struct Notes
-    notes::Vector{Note}
+struct Notes{N <: AbstractNote}
+    notes::Vector{N}
     tpq::Int16
-    function Notes(notes, tpq)
-        if tpq < 1 || tpq > 960
-            throw(ArgumentError("Ticks per quarter note (tpq) must ∈ [1, 960]"))
-        end
-        new(notes, tpq)
-    end
 end
 
 # Constructors for Notes:
-Notes(notes::Vector{Note}) = Notes(notes, 960)
-Notes() = Notes(Vector{Note}[], 960)
+function Notes(notes::Vector{N}, tpq::Int = 960) where {N <: AbstractNote}
+    if tpq < 1 || tpq > 960
+        throw(ArgumentError("Ticks per quarter note (tpq) must ∈ [1, 960]"))
+    end
+    Notes{N}(notes, tpq)
+end
+
+Notes() = Notes{Note}(Vector{Note}[], 960)
 
 # Iterator Interface for notes:
 Base.start(n::Notes) = start(n.notes)

--- a/src/note.jl
+++ b/src/note.jl
@@ -27,6 +27,7 @@ mutable struct Note <: AbstractNote
             new(value, duration, position, channel, velocity)
         end
 end
+Note(n::Note) = n
 
 import Base.+, Base.-, Base.==
 
@@ -82,8 +83,8 @@ Base.getindex(n::Notes, i::Int) = n.notes[i]
 Base.getindex(n::Notes, r::AbstractVector{Int}) = Notes(n.notes[r], n.tpq)
 
 # Pushing
-Base.push!(no::Notes, n::Note) = push!(no.notes , n)
-function Base.append!(n1::Notes, n2::Notes)
+Base.push!(no::Notes{N}, n::N) where {N <: AbstractNote} = push!(no.notes, n)
+function Base.append!(n1::Notes{N}, n2::Notes{N}) where {N}
     n1.tpq == n2.tpq || throw(ArgumentError("The Notes do not have same tpq."))
     append!(n1.notes, n2.notes)
     return n1

--- a/test/note.jl
+++ b/test/note.jl
@@ -6,7 +6,6 @@
     end
 end
 
-
 cd(@__DIR__)
 
 @testset "Notes" begin
@@ -16,6 +15,7 @@ cd(@__DIR__)
 
     @test notes.tpq == 960
     @test typeof(notes[1]) == Note
-    @test typeof(notes[1:3]) == Notes
+    @test typeof(notes[1:3]) == Notes{Note}
+    @test typeof(notes[1:3]) <: Notes
     @test notes[1:3].notes == notes.notes[1:3]
 end


### PR DESCRIPTION
The Roland TD-50 (newest e-drum flagship) supports notes with Velocity values up to 127+32 (allows for 32 more values somehow).

The current `Note` cannot support that, and in my eyes it **should not**. However, by defining `AbstractNote` and making current `Note` a subtype, this allows us to define some other note in our scipts that can take advantage of all the functions in the library (and in another library that we are developing) that dispatch on `Note`/`Notes`.

For this `Notes` is now a parameteric type.